### PR TITLE
Queue album feature

### DIFF
--- a/src/main/java/app/MusicAppDemo.java
+++ b/src/main/java/app/MusicAppDemo.java
@@ -25,6 +25,8 @@ import javafx.beans.value.ChangeListener;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Scene;
+import javafx.scene.control.ContextMenu;
+import javafx.scene.control.MenuItem;
 import javafx.scene.control.TreeView;
 import javafx.scene.control.TreeCell;
 import javafx.scene.control.TreeItem;
@@ -54,7 +56,6 @@ import java.util.HashMap;
 import java.util.ArrayList;
 import java.util.Queue;
 import java.util.Comparator;
-import java.util.Iterator;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -125,6 +126,8 @@ public class MusicAppDemo extends Application {
         treeView.getSelectionModel().selectedItemProperty().addListener((_, _, newSel) ->
             handleTreeSelection(newSel)
         );
+
+        setupAlbumContextMenu();
 
         albumOrderManager = new AlbumOrderManager();
         stateManager = new StateManager(this, albumOrderManager);
@@ -339,6 +342,47 @@ public class MusicAppDemo extends Application {
         treeView.setRoot(rootItem);
     }
 
+    private void setupAlbumContextMenu() {
+        treeView.setOnContextMenuRequested(event -> {
+            TreeItem<String> item = treeView.getSelectionModel().getSelectedItem();
+            if (item == null || item.getParent() == null) return;
+
+            // Only show for album nodes (non-leaf, child of root)
+            if (!item.isLeaf() && item.getParent().getParent() == null) {
+                ContextMenu contextMenu = new ContextMenu();
+                MenuItem queueAll = new MenuItem("Queue All Songs");
+                queueAll.setOnAction(_ -> queueAlbum(item.getValue()));
+                contextMenu.getItems().add(queueAll);
+                contextMenu.show(treeView, event.getScreenX(), event.getScreenY());
+                event.consume();
+            }
+        });
+    }
+
+    private void queueAlbum(String albumName) {
+        Album album = library.getAlbumByName(albumName);
+        if (album == null) return;
+
+        List<Song> queueable = album.getQueueableSongs(enabledSets, unlockedSongs, unlockedAlbums);
+        if (queueable.isEmpty()) {
+            LOGGER.info("No queueable songs in album '{}'", albumName);
+            return;
+        }
+
+        playQueue.addAll(queueable);
+        LOGGER.info("Queued {} songs from album '{}'", queueable.size(), albumName);
+        updateQueueDisplay();
+
+        // If nothing is playing, start the first queued song
+        if ((currentPlayer == null || currentPlayer.getStatus() != MediaPlayer.Status.PLAYING) && !playQueue.isEmpty()) {
+            Song next = playQueue.poll();
+            updateQueueDisplay();
+            if (next != null) {
+                playSong(next);
+            }
+        }
+    }
+
     public void unlockSong(String songTitle) {
         if (!unlockedSongs.contains(songTitle)) {
             unlockedSongs.add(songTitle);
@@ -487,23 +531,12 @@ public class MusicAppDemo extends Application {
     private void updateQueueDisplay() {
         playerPanel.clearQueueDisplay();
         for (Song s : playQueue) {
-            playerPanel.addToQueueDisplay(s.getTitle());
-        }
-        if (playQueue.isEmpty()) {
-            playerPanel.addToQueueDisplay("(empty)");
+            playerPanel.addToQueueDisplay(s);
         }
     }
 
-    private void removeFromQueue(String title) {
-        // remove first occurrence in queue matching title
-        Iterator<Song> it = playQueue.iterator();
-        while (it.hasNext()) {
-            Song s = it.next();
-            if (s.getTitle().equals(title)) {
-                it.remove();
-                return;
-            }
-        }
+    private void removeFromQueue(Song song) {
+        playQueue.remove(song);
     }
 
     private void assignFilesToSongs() {
@@ -803,7 +836,7 @@ public class MusicAppDemo extends Application {
 
         // Remove selected from the queue (both ListView and underlying queue)
         panel.getRemoveSelectedBtn().setOnAction(_ -> {
-            String sel = playerPanel.getQueueListView().getSelectionModel().getSelectedItem();
+            Song sel = playerPanel.getQueueListView().getSelectionModel().getSelectedItem();
             if (sel != null) {
                 removeFromQueue(sel);
                 updateQueueDisplay();

--- a/src/main/java/app/player/Album.java
+++ b/src/main/java/app/player/Album.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.Set;
 
 public class Album {
 
@@ -67,4 +68,22 @@ public class Album {
     public boolean isFullAlbumUnlock() { return fullAlbumUnlock; }
     @SuppressWarnings("unused")
     public void setFullAlbumUnlock(boolean fullAlbumUnlock) { this.fullAlbumUnlock = fullAlbumUnlock; }
+
+    public List<Song> getQueueableSongs(Set<String> enabledSets, Set<String> unlockedSongs, Set<String> unlockedAlbums) {
+        List<Song> queueable = new ArrayList<>();
+        boolean albumUnlocked = unlockedAlbums.contains(name);
+
+        for (Song song : songs) {
+            if (!enabledSets.contains(song.getType())) continue;
+
+            boolean songUnlocked = unlockedSongs.contains(song.getTitle());
+            boolean canPlay = fullAlbumUnlock || (songUnlocked && albumUnlocked);
+
+            if (!canPlay) continue;
+
+            queueable.add(song);
+        }
+
+        return queueable;
+    }
 }

--- a/src/main/java/app/player/ui/PlayerPanel.java
+++ b/src/main/java/app/player/ui/PlayerPanel.java
@@ -1,11 +1,13 @@
 package app.player.ui;
 
+import app.player.Song;
 import javafx.beans.value.ChangeListener;
 import javafx.geometry.Pos;
 import javafx.scene.control.Label;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.Slider;
 import javafx.scene.control.ListView;
+import javafx.scene.control.ListCell;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.control.Button;
 import javafx.scene.input.ScrollEvent;
@@ -25,7 +27,7 @@ public class PlayerPanel extends VBox {
 
     private final HBox progressBox;
 
-    private final ListView<String> queueListView;
+    private final ListView<Song> queueListView;
     private final ScrollPane queueScrollPane;
 
     private final HBox queueButtons;
@@ -59,6 +61,19 @@ public class PlayerPanel extends VBox {
 
         queueListView = new ListView<>();
         queueListView.setPrefHeight(120);
+        queueListView.setCellFactory(_ -> new ListCell<>() {
+            @Override
+            protected void updateItem(Song song, boolean empty) {
+                super.updateItem(song, empty);
+                if (empty || song == null) {
+                    setText(null);
+                    setStyle("");
+                } else {
+                    setText(song.getTitle());
+                    setStyle("-fx-text-fill: black;");
+                }
+            }
+        });
 
         queueScrollPane = new ScrollPane(queueListView);
         queueScrollPane.setHbarPolicy(ScrollPane.ScrollBarPolicy.ALWAYS);
@@ -100,7 +115,7 @@ public class PlayerPanel extends VBox {
     public Button getRemoveSelectedBtn() { return removeSelectedBtn; }
     public Button getClearQueueBtn() { return clearQueueBtn; }
 
-    public ListView<String> getQueueListView() { return queueListView; }
+    public ListView<Song> getQueueListView() { return queueListView; }
 
     public CheckBox getEnableSeekCheck() { return enableSeekCheck; }
     public Slider getProgressSlider() { return progressSlider; }
@@ -113,8 +128,8 @@ public class PlayerPanel extends VBox {
         currentSongLabel.setText(text);
     }
 
-    public void addToQueueDisplay(String title) {
-        queueListView.getItems().add(title);
+    public void addToQueueDisplay(Song song) {
+        queueListView.getItems().add(song);
     }
 
     public void clearQueueDisplay() {

--- a/src/main/java/app/util/Normalization.java
+++ b/src/main/java/app/util/Normalization.java
@@ -30,7 +30,9 @@ public class Normalization {
     // Levenshtein distance helper
     public static int levenshteinDistance(String a, String b) {
         int[] costs = new int[b.length() + 1];
-        for (int j = 0; j < costs.length; j++) costs[j] = j;
+        for (int j = 0; j < costs.length; j++) {
+            costs[j] = j;
+        }
         for (int i = 1; i <= a.length(); i++) {
             costs[0] = i;
             int nw = i - 1;

--- a/src/test/java/app/player/AlbumTest.java
+++ b/src/test/java/app/player/AlbumTest.java
@@ -1,0 +1,118 @@
+package app.player;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AlbumTest {
+
+    @Test
+    void getQueueableSongs_returnsAllSongs_whenFullAlbumUnlock() {
+        Album album = new Album("Test Album", "standard", true);
+        album.addSong(new Song("Song A", "standard"));
+        album.addSong(new Song("Song B", "standard"));
+
+        List<Song> result = album.getQueueableSongs(
+                Set.of("standard"), Set.of(), Set.of()
+        );
+
+        assertEquals(2, result.size());
+    }
+
+    @Test
+    void getQueueableSongs_returnsNothing_whenAlbumLockedAndSongsLocked() {
+        Album album = new Album("Test Album", "standard", false);
+        album.addSong(new Song("Song A", "standard"));
+
+        List<Song> result = album.getQueueableSongs(
+                Set.of("standard"), Set.of(), Set.of()
+        );
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void getQueueableSongs_returnsNothing_whenTypeDisabled() {
+        Album album = new Album("Test Album", "standard", true);
+        album.addSong(new Song("Song A", "vault"));
+
+        List<Song> result = album.getQueueableSongs(
+                Set.of("standard"), Set.of(), Set.of()
+        );
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void getQueueableSongs_requiresBothSongAndAlbumUnlock_whenNotFullAlbumUnlock() {
+        Album album = new Album("Test Album", "standard", false);
+        Song song = new Song("Song A", "standard");
+        album.addSong(song);
+
+        // Song unlocked but album locked → cannot play
+        List<Song> withSongUnlock = album.getQueueableSongs(
+                Set.of("standard"), Set.of("Song A"), Set.of()
+        );
+        assertTrue(withSongUnlock.isEmpty());
+
+        // Album unlocked but song locked → cannot play
+        List<Song> withAlbumUnlock = album.getQueueableSongs(
+                Set.of("standard"), Set.of(), Set.of("Test Album")
+        );
+        assertTrue(withAlbumUnlock.isEmpty());
+
+        // Both unlocked → can play
+        List<Song> bothUnlocked = album.getQueueableSongs(
+                Set.of("standard"), Set.of("Song A"), Set.of("Test Album")
+        );
+        assertEquals(1, bothUnlocked.size());
+    }
+
+    @Test
+    void getQueueableSongs_mixedSongTypes_onlyIncludesEnabledOnes() {
+        Album album = new Album("Test Album", "standard", true);
+        album.addSong(new Song("Song A", "standard"));
+        album.addSong(new Song("Song B", "vault"));
+        album.addSong(new Song("Song C", "short"));
+
+        List<Song> result = album.getQueueableSongs(
+                Set.of("standard", "short"), Set.of(), Set.of()
+        );
+
+        assertEquals(2, result.size());
+        assertTrue(result.stream().anyMatch(s -> s.getTitle().equals("Song A")));
+        assertTrue(result.stream().anyMatch(s -> s.getTitle().equals("Song C")));
+    }
+
+    @Test
+    void getQueueableSongs_handlesEmptyAlbum() {
+        Album album = new Album("Empty Album", "standard", true);
+
+        List<Song> result = album.getQueueableSongs(
+                Set.of("standard"), Set.of(), Set.of()
+        );
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void getQueueableSongs_filtersByAlbumUnlockName() {
+        Album album = new Album("Specific Album", "standard", false);
+        album.addSong(new Song("Song A", "standard"));
+
+        // Album with different name unlocked → should not match
+        List<Song> wrongAlbum = album.getQueueableSongs(
+                Set.of("standard"), Set.of("Song A"), Set.of("Wrong Album")
+        );
+        assertTrue(wrongAlbum.isEmpty());
+
+        // Correct album name unlocked → should match
+        List<Song> correctAlbum = album.getQueueableSongs(
+                Set.of("standard"), Set.of("Song A"), Set.of("Specific Album")
+        );
+        assertEquals(1, correctAlbum.size());
+    }
+}


### PR DESCRIPTION
this adds the feature described in #1. Queueing an album is now possible by right clicking and selecting an option in the context menu.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an album context menu option to queue all eligible songs.
  * Queueing now respects enabled content and song or album unlock status.
  * Queued songs automatically begin playback when nothing is currently playing.

* **Improvements**
  * Queue items retain song information while displaying song titles.
  * Removing a selected song from the queue is more reliable.

* **Tests**
  * Added coverage for album queue eligibility across unlock and filtering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->