### PR TITLE
add offline mode for standalone playback without Archipelago

### DIFF
--- a/src/main/java/app/MusicAppDemo.java
+++ b/src/main/java/app/MusicAppDemo.java
@@ -83,6 +83,7 @@ public class MusicAppDemo extends Application {
     private final Set<String> unlockedSongs = new HashSet<>();
     private final Set<String> enabledSets = new HashSet<>();
     private final Set<String> enabledAlbums = new HashSet<>();
+    private boolean offlineMode = false;
     private AlbumLibrary library;
 
     private AlbumOrderManager albumOrderManager;
@@ -162,6 +163,15 @@ public class MusicAppDemo extends Application {
                 connectToServer(gameFolder);
             } else {
                 disconnectFromServer();
+            }
+        });
+
+        // Offline mode toggle
+        connectionPanel.getOfflineCheck().selectedProperty().addListener((_, _, isOffline) -> {
+            if (isOffline) {
+                enableOfflineMode();
+            } else {
+                disableOfflineMode();
             }
         });
     }
@@ -283,6 +293,11 @@ public class MusicAppDemo extends Application {
             assignFilesToSongs();
 
             refreshTree(); // populate TreeView after loading
+
+            // If offline mode was activated before load finished, apply it now
+            if (offlineMode) {
+                applyOfflineUnlocks();
+            }
         });
 
         loadTask.setOnFailed(_ -> {
@@ -654,6 +669,59 @@ public class MusicAppDemo extends Application {
         }
     }
 
+    private void enableOfflineMode() {
+        offlineMode = true;
+
+        // Disconnect any active connection first
+        if (client != null && client.isConnected()) {
+            client.disconnect();
+            connectionPanel.setConnectButtonText("Connect");
+            connectionPanel.disableGameField(false);
+            connectionPanel.setGameFieldTooltip(null);
+        }
+
+        connectionPanel.setStatus("Offline Mode");
+        connectionPanel.setConnectionFieldsDisabled(true);
+
+        if (!albums.isEmpty()) {
+            applyOfflineUnlocks();
+        }
+        // If albums aren't loaded yet, applyOfflineUnlocks will be called in onSucceeded
+    }
+
+    private void disableOfflineMode() {
+        offlineMode = false;
+        connectionPanel.setStatus("Not connected");
+        connectionPanel.setConnectionFieldsDisabled(false);
+
+        if (client != null) {
+            client.disconnect();
+        }
+
+        stateManager.clearUnlocks();
+        enabledAlbums.clear();
+        refreshTree();
+    }
+
+    private void applyOfflineUnlocks() {
+        enabledSets.clear();
+        enabledAlbums.clear();
+        unlockedAlbums.clear();
+        unlockedSongs.clear();
+
+        for (Album album : albums) {
+            enabledAlbums.add(album.getName());
+            enabledSets.add(album.getType());
+            unlockedAlbums.add(album.getName());
+
+            for (Song song : album.getSongs()) {
+                unlockedSongs.add(song.getTitle());
+            }
+        }
+
+        refreshTree();
+    }
+
     public void stopCurrentSong() {
         if (currentPlayer != null) {
             currentPlayer.stop();
@@ -829,7 +897,7 @@ public class MusicAppDemo extends Application {
 
         Album album = library.getAlbumForSong(songTitle);
         boolean songUnlocked = unlockedSongs.contains(song.getTitle());
-        boolean albumUnlocked = album != null && unlockedAlbums.contains(album.getType());
+        boolean albumUnlocked = album != null && unlockedAlbums.contains(album.getName());
 
         // Check unlocking rules
         if (!songUnlocked || !albumUnlocked) {

--- a/src/main/java/app/player/ui/ConnectionPanel.java
+++ b/src/main/java/app/player/ui/ConnectionPanel.java
@@ -4,6 +4,7 @@ import app.archipelago.APClient;
 import app.archipelago.SlotDataHelper;
 import javafx.geometry.Pos;
 import javafx.scene.control.Button;
+import javafx.scene.control.CheckBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
 import javafx.scene.control.Tooltip;
@@ -30,6 +31,7 @@ public class ConnectionPanel extends VBox {
     private final Button connectButton;
     private final Label statusLabel;
     private final Button showTextClientBtn;
+    private final CheckBox offlineCheck;
     private final HBox connectButtonsBox;
     private TextClientWindow textClientWindow;
 
@@ -71,6 +73,9 @@ public class ConnectionPanel extends VBox {
         textClientWindow = new TextClientWindow(clientSupplier);
         showTextClientBtn.setOnAction(_ -> textClientWindow.show());
 
+        offlineCheck = new CheckBox("Offline Mode");
+        offlineCheck.setSelected(false);
+
         // Create a horizontal container for connect button and text client button
         connectButtonsBox = new HBox(10);
         connectButtonsBox.setAlignment(Pos.CENTER_LEFT);
@@ -83,6 +88,7 @@ public class ConnectionPanel extends VBox {
                 new Label("Slot:"), slotField,
                 new Label("Password:"), passwordField,
                 connectButtonsBox,
+                offlineCheck,
                 statusLabel
         );
         setAlignment(Pos.CENTER_LEFT);
@@ -135,6 +141,19 @@ public class ConnectionPanel extends VBox {
 
     public void setConnectButtonText(String text) {
         connectButton.setText(text);
+    }
+
+    public CheckBox getOfflineCheck() {
+        return offlineCheck;
+    }
+
+    public void setConnectionFieldsDisabled(boolean disabled) {
+        hostField.setDisable(disabled);
+        portField.setDisable(disabled);
+        slotField.setDisable(disabled);
+        passwordField.setDisable(disabled);
+        connectButton.setDisable(disabled);
+        showTextClientBtn.setDisable(disabled);
     }
 
     public TextClientWindow getTextClientWindow() {


### PR DESCRIPTION
- Add Offline Mode checkbox to ConnectionPanel
- Auto-unlock all albums and songs when offline
- Disable connection fields in offline mode
- Disconnect active client when switching to offline
- Apply unlocks on load if offline flag was set early
- Fix pre-existing bug in handleTreeSelection (album.getType -> getName)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Offline Mode option to the music app.
  * Users can switch between connected and offline play directly from the connection panel.
  * Offline mode calculates album, album type, and song unlock states locally when library data is available.
  * Connection controls are updated automatically when offline mode is enabled or disabled.

* **Bug Fixes**
  * Corrected album unlock checks when selecting items for queuing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->